### PR TITLE
Changed charm name to 'cinder-volume'

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-name: cinder
+name: cinder-volume
 summary: "OpenStack block storage service"
 maintainer: Ionut-Madalin Balutoiu <ibalutoiu@cloudbasesolutions.com>
 description: |


### PR DESCRIPTION
Renaming is made due to the fact that this charm offers only cinder-volume service on Windows